### PR TITLE
feat: add `Button` component in 3 variations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import type { RootState } from "core/store/store";
 import { Card } from "components/ui/Card";
 import { ImportContacts } from "@mui/icons-material";
 import { Navbar } from "components/Navbar/Navbar";
+import { Button } from "components/ui/Button";
 
 const App: React.FC = () => {
     const { theme } = useSelector((state: RootState) => state.ui);
@@ -32,6 +33,9 @@ const App: React.FC = () => {
                     <C.TitleBig>Фізичне виховання</C.TitleBig>
                 </Card>
             </C.Container>
+            <Button>Filled</Button>
+            <Button variant="outlined">Outlined</Button>
+            <Button variant="text">Text</Button>
             <Navbar>
                 <Navbar.Item isActive={true}>
                     <Navbar.Icon badgeCount={4}>

--- a/src/components/ui/Button/Button.tsx
+++ b/src/components/ui/Button/Button.tsx
@@ -1,0 +1,111 @@
+import styled, { css } from "styled-components";
+import { transparentize } from "polished";
+
+import getTransition from "core/utils/getTransition";
+
+interface Props {
+    variant?: "filled" | "outlined" | "text";
+}
+
+const Button = styled.button<Props>`
+    display: inline-flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+
+    padding: 10px 24px;
+
+    border-radius: 100px;
+
+    border: none;
+    outline: none;
+
+    cursor: pointer;
+
+    text-align: center;
+    font-family: "Roboto", sans-serif;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 20px;
+    letter-spacing: 0.1px;
+
+    ${getTransition(300, ["box-shadow", "background-color", "border"])};
+
+    ${({ theme, variant }) => {
+        switch (variant) {
+            case "filled":
+                return css`
+                    color: ${({ theme }) => theme.colors.primaryText};
+                    background-color: ${theme.colors.primary};
+
+                    &:hover {
+                        box-shadow:
+                            0px 1px 3px 1px rgba(0, 0, 0, 0.15),
+                            0px 1px 2px 0px rgba(0, 0, 0, 0.3);
+                    }
+
+                    &:active,
+                    &:focus {
+                        background-color: ${transparentize(
+                            0.12,
+                            theme.colors.primary
+                        )};
+                    }
+                    &:disabled {
+                        background-color: ${transparentize(
+                            0.9,
+                            theme.colors.primary
+                        )};
+                        &:hover {
+                            box-shadow: none;
+                            cursor: auto;
+                        }
+                    }
+                `;
+            case "outlined":
+                return css`
+                    color: ${theme.colors.primary};
+                    background-color: transparent;
+                    border: 1px solid ${theme.colors.outline};
+
+                    &:active,
+                    &:focus {
+                        border: 1px solid ${theme.colors.primary};
+                    }
+                    &:disabled {
+                        background-color: ${transparentize(
+                            0.9,
+                            theme.colors.primary
+                        )};
+                        &:hover {
+                            cursor: auto;
+                        }
+                    }
+                `;
+            case "text":
+                return css`
+                    color: ${theme.colors.primary};
+                    background-color: transparent;
+                    &:disabled {
+                        background-color: ${transparentize(
+                            0.9,
+                            theme.colors.primary
+                        )};
+                        &:hover {
+                            cursor: auto;
+                        }
+                    }
+                `;
+            default:
+                break;
+        }
+    }}
+`;
+
+Button.defaultProps = {
+    variant: "filled",
+};
+
+export { Button };

--- a/src/components/ui/Button/index.ts
+++ b/src/components/ui/Button/index.ts
@@ -1,0 +1,1 @@
+export * from "./Button";


### PR DESCRIPTION
### Done:

- Added `Button `component

Usage:
Just use this component like regular button. You can choose button style with `variant` property:
```jsx
<Button>Filled</Button>
<Button variant="outlined">Outlined</Button>
<Button variant="text">Text</Button>
```

![chrome_OAtnvLzRG4](https://github.com/nure-dev/nure-schedule/assets/47219330/34bc19f1-fa4b-4daf-be4d-169b4ec33fe6)
![chrome_RX6gHmTOpy](https://github.com/nure-dev/nure-schedule/assets/47219330/6de998e0-b67c-4635-928f-9bd32be258db)
