### PR TITLE
feat: add both `Tabs` and `Dialog` components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
                 "@emotion/styled": "^11.11.0",
                 "@mui/icons-material": "^5.14.8",
                 "@mui/styled-engine": "^5.14.8",
+                "@radix-ui/react-dialog": "^1.0.4",
+                "@radix-ui/react-tabs": "^1.0.4",
                 "@reduxjs/toolkit": "^1.9.5",
                 "axios": "^1.5.0",
                 "react": "^18.2.0",
@@ -3026,6 +3028,433 @@
                 "url": "https://opencollective.com/popperjs"
             }
         },
+        "node_modules/@radix-ui/primitive": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.0.1.tgz",
+            "integrity": "sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            }
+        },
+        "node_modules/@radix-ui/react-collection": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.0.3.tgz",
+            "integrity": "sha512-3SzW+0PW7yBBoQlT8wNcGtaxaD0XSu0uLUFgrtHY08Acx05TaHaOmVLR73c0j/cqpDy53KBMO7s0dx2wmOIDIA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-slot": "1.0.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.0.1.tgz",
+            "integrity": "sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-context": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.0.1.tgz",
+            "integrity": "sha512-ebbrdFoYTcuZ0v4wG5tedGnp9tzcV8awzsxYph7gXUyvnNLuTIcCk1q17JEbnVhXAKG9oX3KtchwiMIAYp9NLg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dialog": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.0.4.tgz",
+            "integrity": "sha512-hJtRy/jPULGQZceSAP2Re6/4NpKo8im6V8P2hUqZsdFiSL8l35kYsw3qbRI6Ay5mQd2+wlLqje770eq+RJ3yZg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-dismissable-layer": "1.0.4",
+                "@radix-ui/react-focus-guards": "1.0.1",
+                "@radix-ui/react-focus-scope": "1.0.3",
+                "@radix-ui/react-id": "1.0.1",
+                "@radix-ui/react-portal": "1.0.3",
+                "@radix-ui/react-presence": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-slot": "1.0.2",
+                "@radix-ui/react-use-controllable-state": "1.0.1",
+                "aria-hidden": "^1.1.1",
+                "react-remove-scroll": "2.5.5"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-direction": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.0.1.tgz",
+            "integrity": "sha512-RXcvnXgyvYvBEOhCBuddKecVkoMiI10Jcm5cTI7abJRAHYfFxeu+FBQs/DvdxSYucxR5mna0dNsL6QFlds5TMA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-dismissable-layer": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.4.tgz",
+            "integrity": "sha512-7UpBa/RKMoHJYjie1gkF1DlK8l1fdU/VKDpoS3rCCo8YBJR294GwcEHyxHw72yvphJ7ld0AXEcSLAzY2F/WyCg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-callback-ref": "1.0.1",
+                "@radix-ui/react-use-escape-keydown": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-guards": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz",
+            "integrity": "sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-focus-scope": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.3.tgz",
+            "integrity": "sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-callback-ref": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-id": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.0.1.tgz",
+            "integrity": "sha512-tI7sT/kqYp8p96yGWY1OAnLHrqDgzHefRBKQ2YAkBS5ja7QLcZ9Z/uY7bEjPUatf8RomoXM8/1sMj1IJaE5UzQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-layout-effect": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-portal": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.0.3.tgz",
+            "integrity": "sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-primitive": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-presence": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.0.1.tgz",
+            "integrity": "sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-use-layout-effect": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-primitive": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+            "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-slot": "1.0.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-roving-focus": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.0.4.tgz",
+            "integrity": "sha512-2mUg5Mgcu001VkGy+FfzZyzbmuUWzgWkj3rvv4yu+mLw03+mTzbxZHvfcGyFp2b8EkQeMkpRQ5FiA2Vr2O6TeQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-collection": "1.0.3",
+                "@radix-ui/react-compose-refs": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-direction": "1.0.1",
+                "@radix-ui/react-id": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-use-callback-ref": "1.0.1",
+                "@radix-ui/react-use-controllable-state": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slot": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
+            "integrity": "sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-compose-refs": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-tabs": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.0.4.tgz",
+            "integrity": "sha512-egZfYY/+wRNCflXNHx+dePvnz9FbmssDTJBtgRfDY7e8SE5oIo3Py2eCB1ckAbh1Q7cQ/6yJZThJ++sgbxibog==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/primitive": "1.0.1",
+                "@radix-ui/react-context": "1.0.1",
+                "@radix-ui/react-direction": "1.0.1",
+                "@radix-ui/react-id": "1.0.1",
+                "@radix-ui/react-presence": "1.0.1",
+                "@radix-ui/react-primitive": "1.0.3",
+                "@radix-ui/react-roving-focus": "1.0.4",
+                "@radix-ui/react-use-controllable-state": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-callback-ref": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.0.1.tgz",
+            "integrity": "sha512-D94LjX4Sp0xJFVaoQOd3OO9k7tpBYNOXdVhkltUbGv2Qb9OXdrg/CpsjlZv7ia14Sylv398LswWBVVu5nqKzAQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.0.1.tgz",
+            "integrity": "sha512-Svl5GY5FQeN758fWKrjM6Qb7asvXeiZltlT4U2gVfl8Gx5UAv2sMR0LWo8yhsIZh2oQ0eFdZ59aoOOMV7b47VA==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-callback-ref": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-escape-keydown": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.0.3.tgz",
+            "integrity": "sha512-vyL82j40hcFicA+M4Ex7hVkB9vHgSse1ZWomAqV2Je3RleKGO5iM8KMOEtfoSB0PnIelMd2lATjTGMYqN5ylTg==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-use-callback-ref": "1.0.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.0.1.tgz",
+            "integrity": "sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@reduxjs/toolkit": {
             "version": "1.9.5",
             "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.9.5.tgz",
@@ -3430,6 +3859,17 @@
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
             "dev": true
+        },
+        "node_modules/aria-hidden": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.3.tgz",
+            "integrity": "sha512-xcLxITLe2HYa1cnYnwCjkOO1PqUHQpozB8x9AR0OgWN2woOBi5kSDVxKfd0b7sb1hw5qFeJhXm9H1nu3xSfLeQ==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/array-union": {
             "version": "2.1.0",
@@ -3910,6 +4350,11 @@
             "engines": {
                 "node": ">=0.4.0"
             }
+        },
+        "node_modules/detect-node-es": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+            "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
@@ -4534,6 +4979,14 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/get-nonce": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+            "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/get-stream": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4717,6 +5170,14 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
+        },
+        "node_modules/invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dependencies": {
+                "loose-envify": "^1.0.0"
+            }
         },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
@@ -5566,6 +6027,51 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-remove-scroll": {
+            "version": "2.5.5",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.5.5.tgz",
+            "integrity": "sha512-ImKhrzJJsyXJfBZ4bzu8Bwpka14c/fQt0k+cyFp/PBhTfyDnU5hjOtM4AG/0AMyy8oKzOTR0lDgJIM7pYXI0kw==",
+            "dependencies": {
+                "react-remove-scroll-bar": "^2.3.3",
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.1.0",
+                "use-callback-ref": "^1.3.0",
+                "use-sidecar": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/react-remove-scroll-bar": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.4.tgz",
+            "integrity": "sha512-63C4YQBUt0m6ALadE9XV56hV8BgJWDmmTPY758iIJjfQKt2nYwoUrPk0LXRXcB/yIj82T1/Ixfdpdk68LwIB0A==",
+            "dependencies": {
+                "react-style-singleton": "^2.2.1",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-router": {
             "version": "6.15.0",
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.15.0.tgz",
@@ -5594,6 +6100,28 @@
             "peerDependencies": {
                 "react": ">=16.8",
                 "react-dom": ">=16.8"
+            }
+        },
+        "node_modules/react-style-singleton": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.1.tgz",
+            "integrity": "sha512-ZWj0fHEMyWkHzKYUr2Bs/4zU6XLmq9HsgBURm7g5pAVfyn49DgUiNgY2d4lXRlYSiCif9YBGpQleewkcqddc7g==",
+            "dependencies": {
+                "get-nonce": "^1.0.0",
+                "invariant": "^2.2.4",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-transition-group": {
@@ -6205,8 +6733,7 @@
         "node_modules/tslib": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-            "dev": true
+            "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         },
         "node_modules/type-check": {
             "version": "0.4.0",
@@ -6331,6 +6858,47 @@
             "dev": true,
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/use-callback-ref": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
+            "integrity": "sha512-3FT9PRuRdbB9HfXhEq35u4oZkvpJ5kuYbpqhCfmiZyReuRgpnhDlbr2ZEnnuS0RrJAPn6l23xjFg9kpDM+Ms7w==",
+            "dependencies": {
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/use-sidecar": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.2.tgz",
+            "integrity": "sha512-epTbsLuzZ7lPClpz2TyryBfztm7m+28DlEv2ZCQ3MDr5ssiwyOwGH/e5F9CkfWjJ1t4clvI58yF822/GUkjjhw==",
+            "dependencies": {
+                "detect-node-es": "^1.1.0",
+                "tslib": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "@types/react": "^16.9.0 || ^17.0.0 || ^18.0.0",
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
             }
         },
         "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
         "@emotion/styled": "^11.11.0",
         "@mui/icons-material": "^5.14.8",
         "@mui/styled-engine": "^5.14.8",
+        "@radix-ui/react-dialog": "^1.0.4",
+        "@radix-ui/react-tabs": "^1.0.4",
         "@reduxjs/toolkit": "^1.9.5",
         "axios": "^1.5.0",
         "react": "^18.2.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import type { RootState } from "core/store/store";
 import { Card } from "components/ui/Card";
 import { ImportContacts } from "@mui/icons-material";
 import { Navbar } from "components/Navbar/Navbar";
+import { Tabs } from "components/ui/Tabs";
+import { Dialog } from "components/ui/Dialog";
 
 const App: React.FC = () => {
     const { theme } = useSelector((state: RootState) => state.ui);
@@ -32,7 +34,7 @@ const App: React.FC = () => {
                     <C.TitleBig>Фізичне виховання</C.TitleBig>
                 </Card>
             </C.Container>
-            <Navbar>
+            <Navbar.Root>
                 <Navbar.Item isActive={true}>
                     <Navbar.Icon badgeCount={4}>
                         <ImportContacts />
@@ -57,11 +59,29 @@ const App: React.FC = () => {
                     </Navbar.Icon>
                     Label
                 </Navbar.Item>
-                <Navbar.Item>
-                    <Navbar.Avatar src="https://i.pravatar.cc/80" />
-                    User
-                </Navbar.Item>
-            </Navbar>
+                <Dialog.Root>
+                    <Dialog.Trigger>
+                        <Navbar.Item>
+                            <Navbar.Avatar src="https://i.pravatar.cc/80" />
+                            User
+                        </Navbar.Item>
+                    </Dialog.Trigger>
+                    <Dialog.Content>
+                        <Dialog.Header title="sdsd" />
+                        <p>1212</p>
+                    </Dialog.Content>
+                </Dialog.Root>
+            </Navbar.Root>
+            <Tabs.Root defaultValue="day">
+                <Tabs.List>
+                    <Tabs.Trigger value="day">День</Tabs.Trigger>
+                    <Tabs.Trigger value="week">Тиждень</Tabs.Trigger>
+                    <Tabs.Trigger value="month">Місяць</Tabs.Trigger>
+                </Tabs.List>
+                <Tabs.Content value="day">1212</Tabs.Content>
+                <Tabs.Content value="week">454554</Tabs.Content>
+                <Tabs.Content value="month">weewwewe</Tabs.Content>
+            </Tabs.Root>
         </ThemeProvider>
     );
 };

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -17,8 +17,9 @@ const NavbarComponent = forwardRef<ElementRef<"header">, NavbarProps>(
     }
 );
 
-export const Navbar = Object.assign(NavbarComponent, {
+export const Navbar = { ...{
+    Root: NavbarComponent,
     Avatar: NavbarAvatar,
     Icon: NavbarIcon,
     Item: NavbarItem,
-})
+}};

--- a/src/components/Navbar/index.ts
+++ b/src/components/Navbar/index.ts
@@ -1,0 +1,1 @@
+export * from "./Navbar";

--- a/src/components/ui/Dialog/Content/Content.styles.ts
+++ b/src/components/ui/Dialog/Content/Content.styles.ts
@@ -1,0 +1,30 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import styled from "styled-components";
+import { media } from 'styles/media';
+
+export const StyledDialogContent = styled(DialogPrimitive.Content)`
+  @media ${media.small} {
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-start;
+    align-items: flex-start;
+    position: fixed;
+    width: 100%;
+    height: 500px;
+    background-color: ${({ theme }) => theme.colors.modalBg};
+    overflow-y: scroll;
+    bottom: 0;
+    z-index: 10;
+    box-sizing: border-box;
+    padding: 1.5rem 2rem;
+    border-radius: 20px 20px 0 0; 
+  }
+`;
+
+export const StyledDialogOverlay = styled(DialogPrimitive.Overlay)`
+  position: fixed;
+  inset: 1;
+  background-color: #fff;
+  width: 100%;
+  height: 100%;
+`;

--- a/src/components/ui/Dialog/Content/Content.tsx
+++ b/src/components/ui/Dialog/Content/Content.tsx
@@ -1,0 +1,16 @@
+import { ElementRef, forwardRef } from "react";
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import * as S from "./Content.styles";
+
+export const DialogContent = forwardRef<
+  ElementRef<typeof DialogPrimitive.Content>, 
+  DialogPrimitive.DialogContentProps
+>(({ ...props }, ref) => {
+  return (
+    <DialogPrimitive.Portal>
+      <S.StyledDialogContent ref={ref} {...props} />
+    </DialogPrimitive.Portal>
+  )
+})
+
+DialogContent.displayName = "DialogContent";

--- a/src/components/ui/Dialog/Dialog.tsx
+++ b/src/components/ui/Dialog/Dialog.tsx
@@ -1,0 +1,13 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { DialogContent } from './Content/Content';
+import { DialogHeader } from './Header/Header';
+import { DialogTrigger } from './Trigger/Trigger';
+
+const DialogRoot = DialogPrimitive.Root;
+
+export const Dialog = { ...{
+  Root: DialogRoot,
+  Content: DialogContent,
+  Header: DialogHeader,
+  Trigger: DialogTrigger,
+}};

--- a/src/components/ui/Dialog/Header/Header.styles.ts
+++ b/src/components/ui/Dialog/Header/Header.styles.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+export const StyledDialogHeader = styled.header`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: fit-content;
+`;
+
+export const StyledHeaderTitle = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: ${({ theme }) => theme.colors.textContrast};
+`;
+
+export const StyledCloseButton = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background-color: transparent;
+  border-radius: 8px;
+  border: 0;
+  outline: none;
+  color: ${({ theme }) => theme.colors.text};
+`;

--- a/src/components/ui/Dialog/Header/Header.tsx
+++ b/src/components/ui/Dialog/Header/Header.tsx
@@ -1,0 +1,24 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from "react";
+import * as S from "./Header.styles";
+import { Close } from "@mui/icons-material";
+
+interface DialogHeaderProps extends Omit<ComponentPropsWithoutRef<"header">, "children"> {
+  title: string;
+}
+
+export const DialogHeader = forwardRef<
+  ElementRef<"header">,
+  DialogHeaderProps
+>(({ title, ...props }, ref) => {
+  return (
+    <S.StyledDialogHeader ref={ref} {...props}>
+      <S.StyledHeaderTitle>{title}</S.StyledHeaderTitle>
+      <DialogPrimitive.Close asChild>
+        <S.StyledCloseButton><Close /></S.StyledCloseButton>
+      </DialogPrimitive.Close>
+    </S.StyledDialogHeader>
+  )
+});
+
+DialogHeader.displayName = "DialogHeader";

--- a/src/components/ui/Dialog/Trigger/Trigger.tsx
+++ b/src/components/ui/Dialog/Trigger/Trigger.tsx
@@ -1,0 +1,11 @@
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { ElementRef, forwardRef } from 'react';
+
+export const DialogTrigger = forwardRef<
+  ElementRef<typeof DialogPrimitive.Trigger>,
+  DialogPrimitive.DialogTriggerProps
+>(({ ...props }, ref) => {
+  return <DialogPrimitive.Trigger ref={ref} asChild {...props} />
+});
+
+DialogTrigger.displayName = "DialogTrigger";

--- a/src/components/ui/Dialog/index.ts
+++ b/src/components/ui/Dialog/index.ts
@@ -1,0 +1,1 @@
+export * from "./Dialog";

--- a/src/components/ui/Tabs/Content/Content.tsx
+++ b/src/components/ui/Tabs/Content/Content.tsx
@@ -1,0 +1,3 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+export const TabsContent = TabsPrimitive.Content;

--- a/src/components/ui/Tabs/List/List.styles.ts
+++ b/src/components/ui/Tabs/List/List.styles.ts
@@ -1,0 +1,43 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import styled from 'styled-components';
+import { media } from 'styles/media';
+
+export const StyledList = styled(TabsPrimitive.List)`
+  @media ${media.small} {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    &[data-variant="compact"] {
+      .Trigger {
+        width: 48px;
+        height: 48px;
+        padding: 0 .5rem;
+        font-size: 0;
+      }
+
+      .Trigger::first-letter {
+        font-size: 16px !important;
+      }
+      .Trigger[data-state="active"] {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 120px;
+          font-size: 16px;
+        }
+    }
+
+    &[data-variant="default"] {
+      .Trigger {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 120px;
+        height: 48px;
+        font-size: 16px;
+      }
+    }
+  }
+`;

--- a/src/components/ui/Tabs/List/List.tsx
+++ b/src/components/ui/Tabs/List/List.tsx
@@ -1,0 +1,24 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { ElementRef, forwardRef } from 'react';
+import * as S from "./List.styles";
+
+type ListVariants = "default" | "compact";
+
+interface TabsListProps extends TabsPrimitive.TabsListProps {
+  variant?: ListVariants
+}
+
+export const TabsList = forwardRef<
+  ElementRef<typeof TabsPrimitive.List>,
+  TabsListProps
+>(({ variant, ...props }, ref) => {
+  return (
+    <S.StyledList ref={ref} data-variant={variant} {...props} />
+  )
+});
+
+TabsList.displayName = "TabsList";
+
+TabsList.defaultProps = {
+  variant: "default",
+};

--- a/src/components/ui/Tabs/Tabs.tsx
+++ b/src/components/ui/Tabs/Tabs.tsx
@@ -1,0 +1,7 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+export const TabsRoot = TabsPrimitive.Root;
+
+TabsRoot.defaultProps = {
+  orientation: 'horizontal',
+};

--- a/src/components/ui/Tabs/Trigger/Trigger.styles.ts
+++ b/src/components/ui/Tabs/Trigger/Trigger.styles.ts
@@ -1,0 +1,30 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import styled from 'styled-components';
+import { media } from 'styles/media';
+
+export const StyledTabsTrigger = styled(TabsPrimitive.Trigger)`
+  @media ${media.small} {
+    background-color: ${({ theme }) => theme.colors.appBackground};
+    color: ${({ theme }) => theme.colors.textContrast};
+    border: 1px solid ${({ theme }) => theme.colors.outline};
+    gap: .5rem;
+    svg {
+      display: none;
+      overflow: hidden;
+    }
+    &:first-child {
+      border-radius: 24px 0 0 24px;
+    }
+    &:last-child {
+      border-radius: 0 24px 24px 0;
+    }
+    &[data-state="active"] {
+      background-color: ${({ theme }) => theme.colors.navbarChip};
+      svg {
+        display: block;
+        width: 18px;
+        height: 18px;
+      }
+    }
+  }
+`;

--- a/src/components/ui/Tabs/Trigger/Trigger.tsx
+++ b/src/components/ui/Tabs/Trigger/Trigger.tsx
@@ -1,0 +1,18 @@
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import { ElementRef, forwardRef } from "react";
+import * as S from "./Trigger.styles";
+import { Check } from '@mui/icons-material';
+
+export const TabsTrigger = forwardRef<
+  ElementRef<typeof TabsPrimitive.Trigger>,
+  TabsPrimitive.TabsTriggerProps
+>(({ children, ...props }, ref) => {
+  return (
+    <S.StyledTabsTrigger ref={ref} className="Trigger" {...props}>
+      <Check />
+      {children}
+    </S.StyledTabsTrigger>
+  )
+})
+
+TabsTrigger.displayName = "TabsTrigger";

--- a/src/components/ui/Tabs/index.ts
+++ b/src/components/ui/Tabs/index.ts
@@ -1,0 +1,11 @@
+import { TabsContent } from "./Content/Content";
+import { TabsList } from "./List/List";
+import { TabsRoot } from "./Tabs";
+import { TabsTrigger } from "./Trigger/Trigger";
+
+export const Tabs = { ...{
+  Root: TabsRoot,
+  Content: TabsContent,
+  List: TabsList,
+  Trigger: TabsTrigger,
+}};


### PR DESCRIPTION
## Fixes:

### Changed `Object.assign` method to spread operator in components with dot notation

With this fix came a few changes about how to use components syntax;

```jsx
// Before
<Navbar>
  <Navbar.Item />
  ...
</Navbar>

// After
<Navbar.Root>
  <NavbarItem />
  ...
</Navbar.Root>
````

## Features:

### Added `Dialog` component

#### Anatomy

```jsx
<Dialog.Root>
 <Dialog.Trigger />
 <Dialog.Content>
  <Dialog.Header />
 </Dialog.Content>
</Dialog.Root>
```

### Added `Tabs` component

#### Anatomy

```jsx
<Tabs.Root>
  <Tabs.List>
    <Tabs.Trigger />
  </Tabs.List>
  <Tabs.Content />
</Tabs.Root>
```

#### Examples

![CleanShot 2023-09-13 at 20 28 08@2x](https://github.com/nure-dev/nure-schedule/assets/54176875/87b2767b-479e-4b30-8c2b-823468c8e403)

![CleanShot 2023-09-13 at 20 29 56@2x](https://github.com/nure-dev/nure-schedule/assets/54176875/3bdb3e4c-3dfa-4090-af16-e2efd3a5717d)

![CleanShot 2023-09-13 at 20 32 32@2x](https://github.com/nure-dev/nure-schedule/assets/54176875/03f6b22d-a610-49ed-8e5f-bf2c940462a2)

<img width="230" alt="CleanShot 2023-09-13 at 20 34 08@2x" src="https://github.com/nure-dev/nure-schedule/assets/54176875/f35dd411-e4f2-4a1d-a875-95b15e25c5a8">

